### PR TITLE
move the secret key to .env

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "name": "API Gateway",
+      "request": "launch",
+      "mainClass": "com.sprintify.api.gateway.ApiGatewayApplication",
+      "cwd": "${workspaceFolder}/api-gateway",
+      "envFile": "${workspaceFolder}/api-gateway/src/.env"
+    },
+    {
+      "type": "java",
+      "name": "Identity Service",
+      "request": "launch",
+      "mainClass": "com.sprintify.identityservice.SprintifyApplication",
+      "cwd": "${workspaceFolder}/Identity_service",
+      "envFile": "${workspaceFolder}/Identity_service/src/.env"
+    }
+  ]
+}

--- a/Identity_service/src/main/resources/application.properties
+++ b/Identity_service/src/main/resources/application.properties
@@ -18,7 +18,7 @@ spring.jpa.show-sql=true
 spring.jpa.open-in-view=false
 
 # JWT Configuration
-security.jwt.secret=${JWY-SECRET:${JWT_SECRET}}
+security.jwt.secret=${JWT_SECRET}
 security.jwt.expiration-ms=86400000
 
 

--- a/Identity_service/src/main/resources/application.properties
+++ b/Identity_service/src/main/resources/application.properties
@@ -18,7 +18,7 @@ spring.jpa.show-sql=true
 spring.jpa.open-in-view=false
 
 # JWT Configuration
-security.jwt.secret=a8b3c9d2e1f7g5h6j4k9m2n8p3q7r5s1t6v9ertsdkmndf2y8z0
+security.jwt.secret=${JWY-SECRET:${JWT_SECRET}}
 security.jwt.expiration-ms=86400000
 
 

--- a/api-gateway/.gitignore
+++ b/api-gateway/.gitignore
@@ -31,3 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### .env files ###
+src/.env
+*.env

--- a/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -3,7 +3,7 @@
     {
       "name": "security.jwt.secret",
       "type": "java.lang.String",
-      "description": "The secret key used for signing JWT tokens. It should be a long and random string to ensure the security of the tokens. This value can be set through environment variables (JWY-SECRET or JWT_SECRET) or directly in the application properties."
+      "description": "The secret key used for signing JWT tokens. It should be a long and random string to ensure the security of the tokens. This value can be set through the JWT_SECRET environment variable or directly in the application properties."
     }
   ]
 }

--- a/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/api-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{
+  "properties": [
+    {
+      "name": "security.jwt.secret",
+      "type": "java.lang.String",
+      "description": "The secret key used for signing JWT tokens. It should be a long and random string to ensure the security of the tokens. This value can be set through environment variables (JWY-SECRET or JWT_SECRET) or directly in the application properties."
+    }
+  ]
+}

--- a/api-gateway/src/main/resources/application.properties
+++ b/api-gateway/src/main/resources/application.properties
@@ -8,4 +8,4 @@ spring.cloud.gateway.server.webflux.discovery.locator.lower-case-service-id=true
 eureka.client.service-url.defaultZone=http://localhost:8761/eureka/
 eureka.instance.prefer-ip-address=true
 
-security.jwt.secret=${JWY-SECRET:${JWT_SECRET}}
+security.jwt.secret=${JWT_SECRET}

--- a/api-gateway/src/main/resources/application.properties
+++ b/api-gateway/src/main/resources/application.properties
@@ -8,4 +8,4 @@ spring.cloud.gateway.server.webflux.discovery.locator.lower-case-service-id=true
 eureka.client.service-url.defaultZone=http://localhost:8761/eureka/
 eureka.instance.prefer-ip-address=true
 
-security.jwt.secret=a8b3c9d2e1f7g5h6j4k9m2n8p3q7r5s1t6v9ertsdkmndf2y8z0
+security.jwt.secret=${JWY-SECRET:${JWT_SECRET}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * JWT secret configuration now uses environment variables instead of hardcoded values for enhanced security.

* **Improvements**
  * Added VS Code debugging launch configurations for streamlined local development.
  * Environment configuration files are now properly excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->